### PR TITLE
fix: remove surplus doc-mainnav

### DIFF
--- a/_includes/docs-nav.html
+++ b/_includes/docs-nav.html
@@ -15,6 +15,3 @@
   {% endif %}
 {% endfor %}
 </div>
-<div class="doc-mininav">
-  <a href="/docs/">Documentation</a>
-</div>


### PR DESCRIPTION
Hey there, looks like there is a "Documentation" too much on the docs page (screenshot).
PR just removes that 🎉    

![doc-too-much](https://cloud.githubusercontent.com/assets/7561396/19014785/53ebbfea-87f6-11e6-9ec1-acc3e5c76131.png)
