### PR TITLE
Fix link to install page

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@ layout: default
     <p>
       <a class="btn" href="/docs/">Learn More</a>
       <a class="btn btn--action"
-         href="/docs/howto/install.html">
+         href="/docs/install.html">
         Install Beaker
         <i class="fa fa-download" aria-hidden="true"></i>
       </a>


### PR DESCRIPTION
Current home page call to action button leads to a 404.  This should fix it.