### PR TITLE
Improve social stuff on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 ---
 layout: default
-desc: Beaker is a new peer-to-peer browser for a Web where users control their data and websites are hosted locally. No blockchain required.
-thumb: https://beakerbrowser.com/img/docs/tour-new-site.jpg
+desc: Beaker is a new peer-to-peer browser for a Web where users control their data and websites are hosted locally.
 ---
 <div class="hero">
   <img src="/img/polygons.svg" class="hero__bg" aria-hidden="true">


### PR DESCRIPTION
This is how it currently looks:

![screen shot 2017-06-15 at 12 35 31 pm](https://user-images.githubusercontent.com/1270099/27194177-3df02c3a-51c7-11e7-9cb5-a1b44b1ea433.png)

This update shortens the description so that it doesn't overflow, and uses our logo instead of the screenshot