### PR TITLE
Typo on the home page, under faq, the is repeated twice in a row

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -19,5 +19,5 @@
   question: "Is my site’s traffic encrypted?"
   answer:
     "Yes. Your site’s traffic is encrypted in transit using its URL/public key.
-     So to decrypt the traffic, one must know the the site’s URL."
+     So to decrypt the traffic, one must know the site’s URL."
 

--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -20,4 +20,3 @@
   answer:
     "Yes. Your site’s traffic is encrypted in transit using its URL/public key.
      So to decrypt the traffic, one must know the site’s URL."
-


### PR DESCRIPTION
> Yes. Your site’s traffic is encrypted in transit using its URL/public key. So to decrypt the traffic, one must know the the site’s URL.

Is changed to 

> Yes. Your site’s traffic is encrypted in transit using its URL/public key. So to decrypt the traffic, one must know the site’s URL.