### PR TITLE
Fix Safari gradient transitioning to black

### DIFF
--- a/css/pages/_home.scss
+++ b/css/pages/_home.scss
@@ -20,7 +20,7 @@
       content: '';
       width: 100%;
       height: 40px;
-      background: linear-gradient($header-bg, transparent);
+      background: linear-gradient($header-bg, transparentize($header-bg, 1));
 
       @include respond-to(tall-gradient-hero) {
         height: 60px;


### PR DESCRIPTION
TIL on this one, but Safari implements the spec correctly while the other browsers appear to transition "transparent" to the previously declared color in the gradient:

https://www.w3.org/TR/css3-color/#transparent

<img width="1418" alt="screen shot 2017-08-26 at 3 08 45 am" src="https://user-images.githubusercontent.com/1043478/29739847-aedd6e7a-8a0d-11e7-972e-58fee3cd9e8d.png">

Transitioning to the same color with 0 opacity now has the same look in all browsers:

<img width="1417" alt="screen shot 2017-08-26 at 3 23 23 am" src="https://user-images.githubusercontent.com/1043478/29739853-fb50a240-8a0d-11e7-8171-24a850538de0.png">
