### PR TITLE
Fix broken links

### DIFF
--- a/_docs/tutorials/diff-commit-revert.md
+++ b/_docs/tutorials/diff-commit-revert.md
@@ -9,7 +9,7 @@ The [DatArchive API](/docs/apis/dat.html) provides a simple set of APIs to manag
 
 ## `diff`
 
-Start with the [site you created in the Writing site files tutorial](http://localhost:4000/docs/tutorials/write-site-files.html). Add the following code to the end of the main function:
+Start with the [site you created in the Writing site files tutorial](/docs/tutorials/write-site-files.html). Add the following code to the end of the main function:
 
 <figcaption class="code">js/index.js</figcaption>
 ```js

--- a/_docs/tutorials/listen-for-file-changes.md
+++ b/_docs/tutorials/listen-for-file-changes.md
@@ -9,7 +9,7 @@ The [DatArchive API](/docs/apis/dat.html) provides a simple set of APIs to liste
 
 ## `createFileActivityStream`
 
-Start with the [site you created in the Writing site files tutorial](http://localhost:4000/docs/tutorials/write-site-files.html). Add the following code to the end of the main function:
+Start with the [site you created in the Writing site files tutorial](/docs/tutorials/write-site-files.html). Add the following code to the end of the main function:
 
 <figcaption class="code">js/index.js</figcaption>
 ```js


### PR DESCRIPTION
This PR fixes a few pages which have absolute links pointing to `localhost:4000`.

Thanks for all the hard work with Beaker!