### PR TITLE
Fix Docs pages 301 Redirects

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -6,7 +6,7 @@ order: 1
 
 <div class="callouts-1">
   <div class="container">
-    <a href="/docs/using-beaker" class="callout">
+    <a href="/docs/using-beaker/" class="callout">
       <h2 class="title">
         Using Beaker
       </h2>
@@ -16,7 +16,7 @@ order: 1
       </p>
     </a>
 
-    <a href="/docs/tutorials" class="callout">
+    <a href="/docs/tutorials/" class="callout">
       <h2 class="title">
         Tutorials
       </h2>
@@ -26,7 +26,7 @@ order: 1
       </p>
     </a>
 
-    <a href="/docs/apis" class="callout">
+    <a href="/docs/apis/" class="callout">
       <h2 class="title">
         APIs
       </h2>

--- a/_docs/inside-beaker/faq.md
+++ b/_docs/inside-beaker/faq.md
@@ -71,7 +71,7 @@ This is to protect the privacy of users.
 ### Do I automatically host sites that I've visited or downloaded?
 
 Yes, temporarily.
-If you want to rehost a site permanently, you should [save it to your sites library](/docs/howto/host.html).
+If you want to rehost a site permanently, you should [save it to your sites library](/docs/tutorials/host-outside-of-beaker.html).
 
 ### Who is allowed to change a Dat site?
 


### PR DESCRIPTION
Fixed broken link
Updated 301 redirect links to the final location, for the sake of speed.