### PR TITLE
Change code example to match screenshot in dat.yml

### DIFF
--- a/_data/apis/dat.yml
+++ b/_data/apis/dat.yml
@@ -70,8 +70,8 @@ toplevel_methods:
       <figcaption class="code">example</figcaption>
       ```js
       var archive = await DatArchive.selectArchive({
-        title: 'Hello, world!',
-        buttonLabel: 'My new site'
+        title: 'Select an archive',
+        buttonLabel: 'Submit'
       })
       ```
 


### PR DESCRIPTION
I found the code example for [`DatArchive.selectArchive`](https://beakerbrowser.com/docs/apis/dat.html#datarchive-selectarchive) confusing because I thought the screenshot below was supposed to represent what the code snippet would do.  However, the parameters for `title` and `buttonLabel` don't appear anywhere in the screenshot, which I found very confusing.

This fixes the code snippet so it matches the screenshot below it.  For reference, this is what the screenshot looks like:

> <img src="https://beakerbrowser.com/img/posts/beaker-0-7-2/dat-picker.jpg" alt="screenshot of archive selection dialog">
