### PR TITLE
Fix Hanging Div Tag

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -3,33 +3,32 @@
     <div class="info">
       <img src="/img/team/pfrazee.jpg" class="avatar"/>
 
-        <ul class="links">
-          <li>
-            <i class="fa fa-link"></i>
-            <a href="https://pfrazee.hashbase.io">pfrazee.hashbase.io</a>
-          </li>
+      <ul class="links">
+        <li>
+          <i class="fa fa-link"></i>
+          <a href="https://pfrazee.hashbase.io">pfrazee.hashbase.io</a>
+        </li>
 
-          <li>
-            <i class="fa fa-twitter"></i>
-            <a href="https://twitter.com/pfrazee">@pfrazee</a>
-          </li>
+        <li>
+          <i class="fa fa-twitter"></i>
+          <a href="https://twitter.com/pfrazee">@pfrazee</a>
+        </li>
 
-          <li>
-            <i class="fa fa-github"></i>
-            <a href="https://github.com/pfrazee">@pfrazee</a>
-          </li>
-        </ul>
-      </div>
+        <li>
+          <i class="fa fa-github"></i>
+          <a href="https://github.com/pfrazee">@pfrazee</a>
+        </li>
+      </ul>
+    </div>
 
-      <div class="bio">
-        <h3 class="name">Paul Frazee</h3>
+    <div class="bio">
+      <h3 class="name">Paul Frazee</h3>
 
-        <p class="bio">
-          Creator of Beaker, longtime Node and Web programmer, and distributed
-          systems enthusiast. Previously developer in the
-          <a href="https://www.scuttlebutt.nz/">Secure Scuttlebutt community</a>.
-        </p>
-      </div>
+      <p class="bio">
+        Creator of Beaker, longtime Node and Web programmer, and distributed
+        systems enthusiast. Previously developer in the
+        <a href="https://www.scuttlebutt.nz/">Secure Scuttlebutt community</a>.
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
Bravo on managing to release the site prior to JSconf!

Here's a fix for the hanging div tag on the about page.

<img width="679" alt="screenshot 2018-06-03 14 28 03" src="https://user-images.githubusercontent.com/916253/40890357-595f6d26-673a-11e8-9809-427dcfe95546.png">
