### PR TITLE
remove banner for Decentralized Web Summit

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,18 +4,6 @@ header: light
 desc: Beaker is a new peer-to-peer browser for a Web where users control their data and websites are hosted locally.
 ---
 <div class="hero">
-  <div class="container">
-    <a class="notice" href="https://decentralizedweb.net/">
-      <div class="badge round">
-        July 31
-      </div>
-
-      <span>
-        Decentralized Web Summit, San Francisco
-      </span>
-    </a>
-  </div>
-
   <div class="container columns">
     <div class="col col-1-2">
       <h1 class="tagline">


### PR DESCRIPTION
The event is in the past now so it probably does not make sense
to advertise it anymore.

Unless of course you would like to keep showing this to people so 
they can read about the cool event that happened?