### PR TITLE
Documentation suggestion for Linux users.

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -64,4 +64,4 @@ npm run burnthemall
 
 This invokes [the mad king](http://nerdist.com/wp-content/uploads/2016/05/the-mad-king-game-of-thrones.jpg), who will torch your `node_modules/`, and do the full install/rebuild process. `npm start` should work afterwards.
 
-If that still doesn't work, it's possible the version of Node in your Linux distribution default software package repositories has problems.  The simplest fix is to download and install the latest stable release of Node from [the official website](https://nodejs.org).
+If you are on Linux and `npm run burnthemall` still fails to get Beaker working, it's possible the version of Node in your Linux distribution default software package repositories is out of date.  The simplest fix is to download and install the latest stable release of Node from [the official website](https://nodejs.org).

--- a/install/index.md
+++ b/install/index.md
@@ -63,3 +63,5 @@ npm run burnthemall
 ```
 
 This invokes [the mad king](http://nerdist.com/wp-content/uploads/2016/05/the-mad-king-game-of-thrones.jpg), who will torch your `node_modules/`, and do the full install/rebuild process. `npm start` should work afterwards.
+
+If that still doesn't work, it's possible the version of Node in your Linux distribution default software package repositories has problems.  The simplest fix is to download and install the latest stable release of Node from [the official website](https://nodejs.org).


### PR DESCRIPTION
I ran into problems getting Beaker to run
several times on Linux.  I've had better luck ignoring
the default Node packages in Ubuntu and Debian and instead
going for Node stable from nodejs.org.

It's just a suggestion, feel free to ignore.