### PR TITLE
Fix Safari usage of transparent within Gradients

### DIFF
--- a/css/components/_testimonials.scss
+++ b/css/components/_testimonials.scss
@@ -18,8 +18,8 @@
       display: block;
       content: '';
       width: 100%;
-      height: 100%;
-      background: linear-gradient(to right, $blue 0%, transparent, transparent, $blue 100%);
+      height: 100%; 
+      background:linear-gradient(to right, $blue 0%,rgba($blue,0.001) ,rgba($blue, 0.001), $blue 100%);
     }
   }
 


### PR DESCRIPTION
Safari handles transparent within Gradients as transparent-black. Using the $blue color with nearly 0 opacity instead should fix this behaviour. Tested for unexpected side effects in Safari, Chrome & Firefox.

See : https://css-tricks.com/thing-know-gradients-transparent-black/