### PR TITLE
Add footer to homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -43,5 +43,8 @@
     {% include header-light.html %}
 
     {{ content }}
+
+    <style>.footer { margin-top: 0; filter: grayscale(1); }</style>
+    {% include footer.html %}
   </body>
 </html>


### PR DESCRIPTION
I went to the Beaker homepage looking for the GitHub link but wasn’t able to find it. The footer is missing from the front page. The footer contains important links to GitHub, Twitter, IRC, etc.

The regular blue variant clashes with the mission statement. Applying a grayscale filter as a quickfix. [Screenshot](https://user-images.githubusercontent.com/1102886/67767807-860ffb00-fa51-11e9-9b14-f59191455a56.png).