### PR TITLE
Fix code blocks overflowing the default layout on mobile

### DIFF
--- a/css/pages/_post.scss
+++ b/css/pages/_post.scss
@@ -104,6 +104,7 @@
     padding: 10px;
     background: #f2f2f2;
     font-size: 14px;
+    overflow-x: scroll;
 
     code {
       background: none;


### PR DESCRIPTION
If you're on mobile and you go to `/install`, the layout busts open:

![image](https://user-images.githubusercontent.com/20846414/71316343-5cb19100-243c-11ea-8189-4cf76f44b707.png)

This just defaults those code blocks to scroll if they're overflowing. On mobile this feels like an acceptable compromise and it doesn't get in the way of desktop layout. It also avoids having to write a `@media` query.