### PR TITLE
update install page to link to new AppImage URL

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -25,7 +25,7 @@ title: Installing Beaker
       </p>
     </a>
 
-    <a href="https://github.com/beakerbrowser/beaker/releases/download/1.0.0-prerelease.1/Beaker.Browser-1.0.0-prerelease.1.AppImage" class="col col-1-3 installer linux" target="_blank">
+    <a href="https://github.com/beakerbrowser/beaker/releases/download/1.0.0-prerelease.1/Beaker.Browser-1.0.0-prerelease.1-and-a-half.AppImage" class="col col-1-3 installer linux" target="_blank">
       <h2 class="platform">Linux</h2>
       <i class="platform-icon fa fa-linux"></i>
 


### PR DESCRIPTION
The original 1.0.0-prerelease had an AppImage for Linux which did not work properly. See https://github.com/beakerbrowser/beaker/issues/1568 for more information. The newly uploaded AppImage solves the problems mentioned in the issue so new users should be pointed to this file instead.