### PR TITLE
Add <link> to RSS feed in blog templates.

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -6,6 +6,9 @@
     <title>{{ page.title | default: "Beaker Browser" }}</title>
     <meta name="viewport" content="width=device-width">
 
+    <!-- RSS feed -->
+    <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="Blog">
+
     <!-- SEO -->
     {% include keywords.html %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,6 +6,9 @@
     <title>{{ page.title | default: "Beaker Browser" }}</title>
     <meta name="viewport" content="width=device-width">
 
+    <!-- RSS feed -->
+    <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="Blog">
+
     <!-- SEO -->
     {% include keywords.html %}
 


### PR DESCRIPTION
The feed is already there and seems to work; just the link is missing to discover it. (I am not sure what the logic is behind all the duplication among the templates, I just added the link to the 'blog' and 'post' templates)